### PR TITLE
re-added newElo feature and added highlighting

### DIFF
--- a/src/content/features/add-player-profile-matches-elo.js
+++ b/src/content/features/add-player-profile-matches-elo.js
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h } from 'dom-chef'
 import select from 'select-dom'
-import { getPlayer, getPlayerMatches, getSelf } from '../helpers/faceit-api'
+import { getPlayer, getPlayerMatches } from '../helpers/faceit-api'
 import { getEloChangesByMatches } from '../helpers/elo'
 import {
   getPlayerProfileNickname,
@@ -11,7 +11,6 @@ import {
   hasFeatureAttribute,
   setFeatureAttribute
 } from '../helpers/dom-element'
-import { getIsFreeMember } from '../helpers/membership'
 
 const FEATURE_ATTRIBUTE = 'matches-elo'
 
@@ -46,8 +45,7 @@ export default async parentElement => {
   const nickname = getPlayerProfileNickname()
   const game = getPlayerProfileStatsGame()
   const player = await getPlayer(nickname)
-  const self = await getSelf()
-  const selfIsFreeMember = getIsFreeMember(self)
+  const currentElo = player.games.csgo.faceitElo
 
   const matches = await getPlayerMatches(player.id, game, 21)
   const eloChangesByMatches = await getEloChangesByMatches(matches, game)
@@ -86,19 +84,24 @@ export default async parentElement => {
 
     resultElement.textContent += ` (${eloDiff >= 0 ? '+' : ''}${eloDiff})`
 
-    if (selfIsFreeMember) {
-      return
-    }
-
     const newEloElement = (
       <div
         style={{
+          display: 'flex',
           color: '#fff',
           fontWeight: 'normal',
           textTransform: 'none'
         }}
       >
-        New Elo: {newElo}
+        New Elo:
+        <div
+          style={{
+            color: newElo >= currentElo ? '#32d35a' : '#ff002b',
+            padding: '0 0 0 5px'
+          }}
+        >
+          {newElo}
+        </div>
       </div>
     )
 


### PR DESCRIPTION
Re-enabled the "New Elo"-feature for matches on profiles for free users (Why was it disabled in the first place?).
Further added highlighting of past elo in comparison to the current elo.
![faceit_enhancer_highlighting](https://user-images.githubusercontent.com/21990230/178086738-bd7ecd21-f5cb-4996-aa9e-d896b46d8b22.png)

Follow up of post:s [r/FACEITEnhancer - New elo](https://www.reddit.com/r/FACEITEnhancer/comments/vo0vai/new_elo/), [r/FACEITEnhancer - Problem with enhancer](https://www.reddit.com/r/FACEITEnhancer/comments/vhv60l/problem_with_enhancer/).
