### PR TITLE
Updating actual map pool and server list.

### DIFF
--- a/src/content/helpers/maps.js
+++ b/src/content/helpers/maps.js
@@ -1,15 +1,14 @@
 /* eslint-disable camelcase */
 export default {
   csgo: {
+    de_ancient: 'Ancient',
+    de_anubis: 'Anubis',
     de_dust2: 'Dust2',
-    de_mirage: 'Mirage',
-    de_overpass: 'Overpass',
     de_inferno: 'Inferno',
+    de_mirage: 'Mirage',
     de_nuke: 'Nuke',
-    de_cache: 'Cache',
-    de_train: 'Train',
-    de_vertigo: 'Vertigo',
-    de_ancient: 'Ancient'
+    de_overpass: 'Overpass',
+    de_vertigo: 'Vertigo'
   }
 }
 /* eslint-enable camelcase */

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -2,7 +2,7 @@ export const UPDATE_NOTIFICATION_TYPES = ['tab', 'badge', 'disabled']
 
 export const MATCH_ROOM_VETO_LOCATION_ITEMS = {
   EU: ['UK', 'Sweden', 'France', 'Germany', 'Netherlands'],
-  US: ['Chicago', 'Dallas', 'Denver'],
+  US: ['Chicago', 'Dallas', 'Denver', 'LosAngeles', 'NewYork'],
   Oceania: ['Sydney', 'Melbourne']
 }
 
@@ -11,13 +11,13 @@ export const MATCH_ROOM_VETO_LOCATION_REGIONS = Object.keys(
 )
 
 export const MATCH_ROOM_VETO_MAP_ITEMS = [
-  'de_dust2',
-  'de_mirage',
-  'de_overpass',
-  'de_inferno',
-  'de_nuke',
   'de_ancient',
-  'de_train',
+  'de_anubis',
+  'de_dust2',
+  'de_inferno',
+  'de_mirage',
+  'de_nuke',
+  'de_overpass',
   'de_vertigo'
 ]
 


### PR DESCRIPTION
CSGO Removed dust2 from the official map pool in late 2022 (FACEIT removed train from the pool as it is the oldest one)
The US servers are not something new, I am just updating them now.

Let's update it, it have been more than 6 months.

![map pool](https://github.com/repeekgg/browser-extension/assets/9168865/c0bd6192-3f74-4e9c-a6f0-aab6ff309411)
![servers](https://github.com/repeekgg/browser-extension/assets/9168865/b8093f61-7b38-4c3d-b5d3-800df172b5bf)

